### PR TITLE
Updates actions versions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,16 +5,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 11
+          distribution: zulu
       - name: Run CI
         run: make ci
       - name: Upload artifact
         if: github.ref == 'refs/heads/master'
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: atinternet-dispatcher.zip
           path: release/
+          override: true


### PR DESCRIPTION
# Description

This PR updates the used version of few actions, especially "upload-artifact", as this version will be [decommissioned](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/)
